### PR TITLE
관리자 부재관리 리스트 페이지 마크업

### DIFF
--- a/src/pages/admin/absence/absenceFunc.js
+++ b/src/pages/admin/absence/absenceFunc.js
@@ -1,0 +1,10 @@
+// 기능 추가
+const absenceFunc = async () => {
+  const title = document.querySelector('#title');
+
+  const changeLink = () => (location.href = '/admin/absence');
+
+  title.addEventListener('click', changeLink);
+};
+
+export default absenceFunc;

--- a/src/pages/admin/absence/absenceRender.js
+++ b/src/pages/admin/absence/absenceRender.js
@@ -1,0 +1,111 @@
+import styles from './adminAbsence.module.css';
+
+// 페이지 렌더링
+const absenceRender = () => `
+  <h1>부재 관리</h1>
+
+  <div class="${styles.content}">
+
+    <div class="${styles.searchWrap}">
+      <input type="text" class="${styles.searchInput}" placeholder="검색" />
+      <select name="type" class="${styles.typeSelect}">
+        <option value="">부재 항목 선택</option>
+        <option value="연차">연차</option>
+        <option value="오전반차">오전반차</option>
+        <option value="오후반차">오후반차</option>
+        <option value="외출">외출</option>
+        <option value="공가">공가</option>
+        <option value="병가">병가</option>
+      </select>
+    </div>
+
+    <table class="${styles.absenceList}">
+      <tr>
+        <th scope="col" width="15%">신청일</td>
+        <th scope="col" width="30%">부재기간</td>
+        <th scope="col" width="10%">부재항목</td>
+        <th scope="col" width="10%">세부내용</td>
+        <th scope="col" width="10%">신청자</td>
+      </tr>
+      <tr>
+        <td>2024-10-09</td>
+        <td>2024-10-25 14:00 ~ 2024-10-25 18:00</td>
+        <td>오후반차</td>
+        <td>병원 방문</td>
+        <td>홍길동</td>
+      </tr>
+      <tr>
+        <td>2024-05-01</td>
+        <td>2024-05-10 09:00 ~ 2024-05-10 18:00</td>
+        <td>연차</td>
+        <td>개인 휴가</td>
+        <td>홍길동</td>
+      </tr>
+      <tr>
+        <td>2024-05-01</td>
+        <td>2024-05-10 09:00 ~ 2024-05-10 18:00</td>
+        <td>연차</td>
+        <td>개인 휴가</td>
+        <td>홍길동</td>
+      </tr>
+      <tr>
+        <td>2024-05-01</td>
+        <td>2024-05-10 09:00 ~ 2024-05-10 18:00</td>
+        <td>연차</td>
+        <td>개인 휴가</td>
+        <td>홍길동</td>
+      </tr>
+      <tr>
+        <td>2024-05-01</td>
+        <td>2024-05-10 09:00 ~ 2024-05-10 18:00</td>
+        <td>연차</td>
+        <td>개인 휴가</td>
+        <td>홍길동</td>
+      </tr>
+      <tr>
+        <td>2024-05-01</td>
+        <td>2024-05-10 09:00 ~ 2024-05-10 18:00</td>
+        <td>연차</td>
+        <td>개인 휴가</td>
+        <td>홍길동</td>
+      </tr>
+      <tr>
+        <td>2024-05-01</td>
+        <td>2024-05-10 09:00 ~ 2024-05-10 18:00</td>
+        <td>연차</td>
+        <td>개인 휴가</td>
+        <td>홍길동</td>
+      </tr>
+      <tr>
+        <td>2024-05-01</td>
+        <td>2024-05-10 09:00 ~ 2024-05-10 18:00</td>
+        <td>연차</td>
+        <td>개인 휴가</td>
+        <td>홍길동</td>
+      </tr>
+      <tr>
+        <td>2024-05-01</td>
+        <td>2024-05-10 09:00 ~ 2024-05-10 18:00</td>
+        <td>연차</td>
+        <td>개인 휴가</td>
+        <td>홍길동</td>
+      </tr>
+      <tr>
+        <td>2024-05-01</td>
+        <td>2024-05-10 09:00 ~ 2024-05-10 18:00</td>
+        <td>연차</td>
+        <td>개인 휴가</td>
+        <td>홍길동</td>
+      </tr>
+    </table>
+    
+    <div class="${styles.pagination}">
+      <div class="${styles.pageBtn}"><a href="#" class="${styles.prev}"><</a></div>
+      <div class="${styles.pageBtn} ${styles.active}"><a href="#" class="${styles.num}">1</a></div>
+      <div class="${styles.pageBtn}"><a href="#" class="${styles.next}">></a></div>
+    </div>
+    
+</div>
+  `;
+
+export default absenceRender;

--- a/src/pages/admin/absence/adminAbsence.module.css
+++ b/src/pages/admin/absence/adminAbsence.module.css
@@ -1,0 +1,99 @@
+body {
+  width: 1280px;
+  margin: 0 auto;
+}
+
+h1 {
+  font-size: 30px;
+  font-weight: bold;
+}
+
+.content {
+  margin: 40px auto 0;
+}
+
+.searchWrap {
+  display: flex;
+  justify-content: flex-end;
+}
+.searchInput {
+  width: 180px;
+  height: 25px;
+  box-sizing: border-box;
+  line-height: 25px;
+  padding-left: 5px;
+  border-radius: 4px;
+  border: 1px solid #000;
+}
+.typeSelect {
+  width: 130px;
+  height: 25px;
+  box-sizing: border-box;
+  line-height: 25px;
+  margin-left: 8px;
+  border-radius: 4px;
+  border: 1px solid #000;
+}
+
+.absenceList {
+  width: 100%;
+  line-height: 39px;
+  margin: 42px auto 0;
+  text-align: left;
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+.absenceList th {
+  background-color: #f2f2f2;
+  border: none;
+}
+.absenceList th:first-child,
+.absenceList td:first-child {
+  padding-left: 10px;
+}
+
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 50px;
+}
+.pagination .pageBtn {
+  display: flex;
+  margin-right: 6px;
+}
+.pagination .pageBtn:last-child {
+  margin-right: 0;
+}
+.pagination .pageBtn a {
+  text-decoration: none;
+  width: 33px;
+  height: 33px;
+  box-sizing: border-box;
+  border: 2px solid #f2f2f2;
+  border-radius: 5px;
+  color: #000;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.pagination .pageBtn.active a {
+  color: #fff;
+  border-color: #000;
+  background-color: #000;
+}
+
+
+@media (max-width: 1280px) {
+  .absenceList th:first-child,
+  .absenceList th:nth-child(4),
+  .absenceList td:first-child,
+  .absenceList td:nth-child(4) {
+      display: none;
+  }
+
+  body {
+    width: 90%;
+    margin: 0 auto;
+  }
+}

--- a/src/pages/admin/absence/index.js
+++ b/src/pages/admin/absence/index.js
@@ -1,0 +1,6 @@
+import { default as render } from './absenceRender';
+import { default as init } from './absenceFunc';
+
+const Absence = { render, init };
+
+export default Absence;

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -1,5 +1,6 @@
 import SignIn from '../pages/common/signIn';
 import SignUp from '../pages/common/signUp';
+import AdminAbsence from '../pages/admin/absence';
 
 // 페이지 구조 저장 + 렌더링 페이지 정리
 const routes = {
@@ -8,6 +9,7 @@ const routes = {
   '/signUp': SignUp,
 
   //admin
+  '/admin/absence': AdminAbsence,
 
   //user
 };


### PR DESCRIPTION
### Description
관리자 부재관리 리스트 페이지 마크업

### How To Test
npm run server, npm run dev 후 localhost/admin/absence 화면 진입

### Commits
1. 부재관리 리스트 페이지 마크업 
2. css 작업
3. 반응형 작업
4. 라우팅 작업

### 결과
![image](https://github.com/user-attachments/assets/125a6fca-5155-4224-b778-2e3c636e2c61)
![image (1)](https://github.com/user-attachments/assets/c1f6844f-9dee-4f02-8636-beb1fc951953)
