### PR TITLE
기업공지 리스트 썸네일 이미지 처리

### DIFF
--- a/server/api/notice/common/index.js
+++ b/server/api/notice/common/index.js
@@ -46,35 +46,43 @@ router.get('/', async (req, res) => {
 
     // 검색어 처리
     if (search) {
-      query += ' WHERE NOTICE_TITLE LIKE ? OR NOTICE_CONTENT LIKE ?';
+      query += ' WHERE title LIKE ? OR content LIKE ?';
       const searchParam = `%${search}%`;
       params.push(searchParam, searchParam);
     }
 
     // 정렬 및 페이지네이션
-    query += ' ORDER BY datetime(NOTICE_DATE_TIME) DESC LIMIT ? OFFSET ?';
+    query += ' ORDER BY datetime(date) DESC LIMIT ? OFFSET ?';
     params.push(size, offset);
 
     // 특정 페이지의 notice 데이터 조회
     db.all(query, params, (err, rows) => {
       if (err) {
         console.error(err);
-        res.status(500).json({ error: 'notice 데이터 조회 실패' });
-        return;
-      }
+        res.status(500).json({ error: '공지 데이터 조회 실패' });
+      } else {
+        // 이미지 필드를 Base64로 변환
+        rows = rows.map((row) => {
+          if (row.image) {
+            row.image = Buffer.from(row.image).toString('base64');
+          }
+          return row;
+        });
 
-      res.json({
-        status: 'OK',
-        page,
-        size,
-        totalPage,
-        totalCount,
-        data: rows,
-      });
+        // 결과 반환
+        res.json({
+          status: 'OK',
+          page,
+          size,
+          totalPage,
+          totalCount,
+          data: rows,
+        });
+      }
     });
   } catch (error) {
     console.error(error);
-    res.status(500).json({ error: '총 공지 개수 조회 실패' });
+    res.status(500).json({ error: '공지 총 개수 조회 실패' });
   }
 });
 
@@ -90,21 +98,30 @@ router.get('/:noticeSn', (req, res) => {
       NOTICE_TITLE AS title,
       NOTICE_CONTENT AS content,
       NOTICE_IMAGE AS image,
+      NOTICE_IMAGE_NAME AS image_name,
       NOTICE_DATE_TIME AS date,
       USER_SERIAL_NUMBER AS user_sn 
     FROM NOTICE 
-    WHERE NOTICE_SERIAL_NUMBER = ?
+    WHERE sn = ?
   `;
 
   db.get(query, [noticeSn], (err, row) => {
     if (err) {
       console.error(err);
-      res.status(500).json({ error: 'notice 데이터 조회 실패' });
+      res.status(500).json({ error: '공지 데이터 조회 실패' });
       return;
     } else if (!row) {
-      res.status(404).json({ error: 'notice 데이터 없음' });
+      res.status(404).json({ error: '공지 데이터 없음' });
     } else {
-      res.json(row);
+      res.json({
+        sn: row.sn,
+        title: row.title,
+        content: row.content,
+        image: row.image ? Buffer.from(row.image).toString('base64') : null,
+        image_name: row.image_name,
+        date: row.date,
+        user_sn: row.user_sn,
+      });
     }
   });
 });

--- a/src/pages/common/notice/list/listFunc.js
+++ b/src/pages/common/notice/list/listFunc.js
@@ -73,8 +73,10 @@ const handlePagination = async (event, totalPage) => {
  * @param {number} currentPage 현재 페이지
  */
 const setupPagination = (totalPage, currentPage = 1) => {
-  const paginationContainer = document.getElementById('pagingContainer');
-  paginationContainer.innerHTML = pagination(currentPage, totalPage);
+  if (totalPage > 0) {
+    const paginationContainer = document.getElementById('pagingContainer');
+    paginationContainer.innerHTML = pagination(currentPage, totalPage);
+  }
 };
 
 /**

--- a/src/pages/common/notice/list/listItem/index.js
+++ b/src/pages/common/notice/list/listItem/index.js
@@ -1,14 +1,22 @@
 import styles from './listItem.module.css';
 
-const listItem = (id, title, content, date) => /* HTML */ `
-  <div class="${styles['list-item']}" data-item-id="${id}">
-    <div class="${styles['thumbnail-box']}"></div>
-    <div class="${styles['info-box']}">
-      <div class="${styles.title}">${title}</div>
-      <div class="${styles.content}">${content}</div>
-      <div class="${styles.date}">${date}</div>
+const listItem = (id, title, content, date, image) => {
+  const imageUrl = image
+    ? `background-image: url(data:image/jpeg;base64,${image})`
+    : '';
+  return /* HTML */ `
+    <div class="${styles['list-item']}" data-item-id="${id}">
+      <div
+        class="${styles['thumbnail-box']} ${!imageUrl ? styles.noimg : ''}"
+        style="${imageUrl}"
+      ></div>
+      <div class="${styles['info-box']}">
+        <div class="${styles.title}">${title}</div>
+        <div class="${styles.content}">${content}</div>
+        <div class="${styles.date}">${date}</div>
+      </div>
     </div>
-  </div>
-`;
+  `;
+};
 
 export default listItem;

--- a/src/pages/common/notice/list/listItem/listItem.module.css
+++ b/src/pages/common/notice/list/listItem/listItem.module.css
@@ -7,11 +7,23 @@
 }
 
 .thumbnail-box {
-    background-color: gray;
+    position: relative;
     padding-top: 100%;
     overflow: hidden;
     border-top-left-radius: 4px;
     border-top-right-radius: 4px;
+    background-color: gray;
+    background-size: cover;
+    background-repeat: no-repeat;
+    background-position: center;
+}
+
+.thumbnail-box.noimg::before {
+    content: 'No Image';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
 }
 
 .info-box {

--- a/src/pages/common/notice/list/listRender.js
+++ b/src/pages/common/notice/list/listRender.js
@@ -55,7 +55,8 @@ export const renderNotices = (data) => {
             item.sn,
             item.title,
             item.content,
-            item.date.split(' ')[0]
+            item.date.split(' ')[0],
+            item.image
           );
         })
         .join('')


### PR DESCRIPTION
### 📝 Description

기업공지 리스트 썸네일 이미지 처리 #28 

### 💻 How To Test

```
npm run server
npm run dev
```
기업공지 등록 후 localhost/admin/notice 접속

### 💽 Commits

구현 사항 요약
- feat : 공지 리스트 썸네일 이미지 처리 추가
- feat : 공지 리스트/상세 API에 이미지 처리 추가
- feat : 공지 리스트 썸네일에 no image 마크업 추가


### 🖼 결과

![image](https://github.com/user-attachments/assets/34ab179e-993e-4ef6-962d-39b3477c60c1)
