### PR TITLE
fix : 출근관리 리스트의 출근일자 컬럼에 날짜까지만 보이게 변경

### DIFF
--- a/src/pages/user/work/workRender.js
+++ b/src/pages/user/work/workRender.js
@@ -50,7 +50,7 @@ const workRender = async () => {
 export const renderWorkList = (data) => {
   return data.length > 0 ? data.map((item) => `
     <tr>
-      <td>${item.WORK_DATE}</td>
+      <td>${item.WORK_DATE.split(' ')[0]}</td>
       <td>${item.WORK_START_DATE_TIME.split(' ')[1].slice(0, 5)}</td>
       <td>${item.WORK_END_DATE_TIME.split(' ')[1].slice(0, 5)}</td>
     </tr>`


### PR DESCRIPTION
### 📝 Description

출근관리 리스트의 출근일자 컬럼에 날짜까지만 보이게 변경

### 💻 How To Test


### 💽 Commits

출근관리 리스트의 출근일자 컬럼에 날짜까지만 보이게 변경

### 🖼 결과
![image](https://github.com/user-attachments/assets/191f99ac-4348-4e9d-8c93-a4af18ea5141)
