### PR TITLE
fix : 출결 신청 페이지 이미지 정보 출력과 기본 이미지 출력되도록 수정

### DIFF
--- a/src/pages/user/workOn/workOn.module.css
+++ b/src/pages/user/workOn/workOn.module.css
@@ -70,7 +70,13 @@
   border-radius: 70%;
   overflow: hidden;
   display: flex;
-  background-color: #d9d9d9;
+}
+
+.workOnImg img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  background-image: url('/src/img/default_user.svg');
 }
 
 .name {

--- a/src/pages/user/workOn/workOnFunc.js
+++ b/src/pages/user/workOn/workOnFunc.js
@@ -27,7 +27,11 @@ const workOnFunc = async () => {
       console.log(error);
     }
     name.innerText = userData['USER_NAME'];
-    profileImg.src = userData['USER_IMAGE'];
+    if (userData['USER_IMAGE']) {
+      profileImg.src = userData['USER_IMAGE'];
+    } else {
+      profileImg.src = '/src/img/default_user.svg';
+    }
   };
 
   const getWorkData = async () => {

--- a/src/pages/user/workOn/workOnRender.js
+++ b/src/pages/user/workOn/workOnRender.js
@@ -6,13 +6,12 @@ const workOnRender = () => `
       <div class="${style.workOnBox}">
         <div class="${style.contentsBox}">
           <div class="${style.boxHeader}">
-            <h1 class="${style.title}">마이 프로필</h1>
             <span id="isWork">출근전</span>
           </div>
           <div class="${style.workOnItem}">
             <div class="${style.division}">임직원</div>
             <div class="${style.workOnImg}">
-              <image id="profileImg" src="/src/img/default_user.svg" alt="프로필 사진"></image>
+              <img id="profileImg" src="/src/img/default_user.svg"></img>
             </div>
             <span id="name" class="${style.name}"></span>
           </div>


### PR DESCRIPTION
### 📝 Description

출결 신청 페이지 이미지 정보 출력과 기본 이미지 출력되도록 수정 #84 

### 💻 How To Test

`
npm run dev
npm run server
`
- 임직원 정보로 로그인 이후 http://localhost:5173/user/workOn 페이지로 접근

### 💽 Commits

구현 사항 요약
1. 출결 신청 페이지의 사용자 프로필 이미지 출력되도록 수정
2. 이미지 존재하지 않을 경우, 기본 이미지 출력 되도록 변경
3. 이미지 출력 수정에 대한 간단한 css 수정


### 🖼 결과

![image](https://github.com/user-attachments/assets/513b18ce-80b6-4ecf-8bc6-1ca1ff5ac3ca)