### PR TITLE
refact : 사용자 권한(userGrade)에 따른 네비게이션 바 출력 조건문 수정

### DIFF
--- a/src/components/layout/layout.js
+++ b/src/components/layout/layout.js
@@ -1,24 +1,31 @@
 import style from './layout.module.css';
 import './style.css';
 const Layout = (children) => {
-  const path = window.location.pathname;
-  const shortCut = path.includes('/user/')
-    ? `
-      <a href="/user/workOn">출결신청</a>
-      <a href="/user/work">출근관리</a>
-      <a href="/user/absence">부재관리</a>
-      <a href="/user/notice">공지사항</a>
-      <a href="/user/profile">프로필</a>`
-    : `
-      <a href="/admin/userList">직원관리</a>
-      <a href="/admin/absence">부재관리</a>
-      <a href="/admin/notice">공지사항</a>`;
+  const userGrade = window.localStorage.getItem('userGrade');
+
+  const navigate = () => {
+    if (userGrade === '0') {
+      // 사용자의 권한이 관리자일 경우
+      return `
+    <a href="/admin/userList">직원관리</a>
+    <a href="/admin/absence">부재관리</a>
+    <a href="/admin/notice">공지사항</a>`;
+    } else if (userGrade === '1') {
+      // 사용자의 권한이 임직원일 경우
+      return `
+    <a href="/user/workOn">출결신청</a>
+    <a href="/user/work">출근관리</a>
+    <a href="/user/absence">부재관리</a>
+    <a href="/user/notice">공지사항</a>
+    <a href="/user/profile">프로필</a>`;
+    }
+  };
 
   return /* HTML */ `
     <div class="${style.layout}">
       <header class="${style.header}">
         <button type="button" id="menu" class="${style.hamburger}"></button>
-        ${shortCut}
+        ${navigate()}
         <div class="${style.headerRightWrap}">
           <h1>인트라넷</h1>
           <button
@@ -31,7 +38,7 @@ const Layout = (children) => {
           </button>
         </div>
         <nav id="navigate" class="${style.navigate} hidden">
-          <div class="${style.shortCut}">${shortCut}</div>
+          <div class="${style.shortCut}">${navigate()}</div>
         </nav>
       </header>
       ${children}


### PR DESCRIPTION
### 📝 Description

사용자 권한에 따른 네비게이션 바 출력 조건 수정 #88 

### 💻 How To Test

터미널에서 `npm run server` 이후,
`npm run dev` 실행
관리자 및 임직원 권한으로 로그인 후에
네비게이션 바 변경됨을 확인

### 💽 Commits

구현 사항 요약
1. 사용자 권한 정보에 맞춰 렌더링 되는 네비게이션 바 형식 변경
2. shortCut에서 navigate로 명칭 변경
3. 삼항연산자를 사용한 변수형태 에서 함수 - 조건식 형태 렌더링으로 변경


### 🖼 결과

![image](https://github.com/user-attachments/assets/dbb9268e-3731-468a-9f15-6f380b8c9c42)
