### PR TITLE
fix : 임직원 관리 페이지 검색 기능 출력된 페이지 단순 필터링에서 검색된 인물 모두 출력되도록 수정 + refact : 기능 리팩토링

### DIFF
--- a/server/api/user/admin/userListRouter.js
+++ b/server/api/user/admin/userListRouter.js
@@ -3,19 +3,52 @@ import db from '../../../database.js';
 
 const router = express.Router();
 
-/**
- * USERLIST 데이터 조회
- */
+//임직원 수 조회 함수
+export const getTotalUsersCount = (search) => {
+  return new Promise((resolve, reject) => {
+    let query = 'SELECT COUNT(*) as totalCount FROM USER';
+    query += search
+      ? ' WHERE USER_NAME LIKE ? OR USER_EMAIL LIKE ?'
+      : '';
+    const params = search ? [`%${search}%`, `%${search}%`] : [];
+
+    db.get(query, params, (err, result) => {
+      if (err) {
+        return reject(err);
+      }
+      resolve(result.totalCount);
+    });
+  });
+};
+
+
+ //USERLIST 데이터 조회
+
 router.get('/', async (req, res) => {
-  let { page, size } = req.query;
+  let { page, size, search } = req.query;
   page = parseInt(page) || 1; // 기본값 1페이지
   size = parseInt(size) || 5; // 출력되는 데이터 수
-
   const offset = (page - 1) * size;
+
+  // 총 개수 가져오기
+  const totalCount = await getTotalUsersCount(search);
+  const totalPage = Math.ceil(totalCount / size);
+
   //임직원 정보 및 페이지네이션 쿼리
-  let query = `SELECT (SELECT COUNT(*) FROM USER) AS USER_COUNT, USER_IMAGE AS image, USER_NAME AS name, USER_EMAIL AS email, USER_PHONE_NUMBER AS phoneNumber, USER_GRADE AS grade, USER_SERIAL_NUMBER AS userSn FROM USER LIMIT ? OFFSET ?`;
+  let query = `SELECT USER_IMAGE AS image, USER_NAME AS name, USER_EMAIL AS email, USER_PHONE_NUMBER AS phoneNumber, USER_GRADE AS grade, USER_SERIAL_NUMBER AS userSn FROM USER `;
+  const pagination = [];
+
+  //검색어 처리
+  if(search){
+    query += 'WHERE name LIKE ? OR email LIKE ?';
+    const searchParam = `%${search}%`
+    pagination.push(searchParam,searchParam);
+  }
+
   //페이지네이션
-  const pagination = [size, offset];
+  query += ' LIMIT ? OFFSET ?';
+  pagination.push(size, offset);
+
   //임직원 리스트 데이터 조회
   db.all(query, pagination, (err, rows) => {
     if (err) {
@@ -25,12 +58,9 @@ router.get('/', async (req, res) => {
         error: 'userList 데이터 조회 실패',
       });
     }
+
     const userList = rows;
-    const totalCount = rows[0].USER_COUNT;
-    const totalPage = Math.ceil(totalCount / size);
-    console.log(totalCount);
-    console.log(userList);
-    console.log(totalPage);
+
     res.json({
       status: 'OK',
       page,

--- a/src/pages/admin/userList/userListFunc.js
+++ b/src/pages/admin/userList/userListFunc.js
@@ -48,17 +48,7 @@ const updateUserList = async (page = 1) => {
 
   setupPagination(totalPage, page);
 };
-//검색
-// const search = async (searchTerm) => {
-//   const data = await fetchUsers()
-//   const userData = data.data
-//   // searchTerm을 포함하는 항목만 필터링
-//   const filteredUsers = userData.filter(user =>
-//     user.name.includes(searchTerm) || user.email.includes(searchTerm)
-//   );
-//   console.log(filteredUsers)
-//   return filteredUsers
-// }
+
 //검색 결과 렌더링
 const filterTableRows = (data) => {
   const curPath = window.location.pathname;

--- a/src/pages/admin/userList/userListFunc.js
+++ b/src/pages/admin/userList/userListFunc.js
@@ -1,10 +1,10 @@
 import { pagination } from './userListRender';
 import { renderTableRows } from './userListRender';
-import style from './userList.module.css';
+// import style from './userList.module.css';
 
 // 임직원 리스트 API 호출 함수
-export const fetchUsers = async (page = 1) => {
-  const url = `/api/admin/userList?page=${page}`;
+export const fetchUsers = async (page = 1, searchTerm = '') => {
+  const url = `/api/admin/userList?page=${page}&search=${searchTerm}`;
   try {
     const response = await fetch(url);
     if (!response.ok) throw new Error('Failed to fetch items');
@@ -13,7 +13,14 @@ export const fetchUsers = async (page = 1) => {
     console.error('Error fetching items:', error);
   }
 };
-
+//검색어 포함 api 호출 함수
+export const getUsers = async (page = 1) => {
+  if (currentSearchTerm) {
+    return await fetchUsers(page, currentSearchTerm);
+  }else{
+    return await fetchUsers(page);
+  };
+}
 // 페이지네이션 버튼 핸들러
 const handlePagination = async (event, totalPage) => {
   const target = event.target;
@@ -34,12 +41,16 @@ const handlePagination = async (event, totalPage) => {
 
 //페이지네이션
 const setupPagination = (totalPage, currentPage = 1) => {
-  const paginationButtons = document.getElementById('paginationButtons');
-  paginationButtons.innerHTML = pagination(currentPage, totalPage);
+  if(totalPage > 0){
+    const paginationButtons = document.getElementById('paginationButtons');
+    paginationButtons.innerHTML = pagination(currentPage, totalPage);
+  }
 };
+
 // 임직원 리스트 업데이트 함수
 const updateUserList = async (page = 1) => {
-  const { data, totalCount, totalPage } = await fetchUsers(page);
+  const { data, totalCount, totalPage } = await getUsers(page);
+  console.log(totalCount)
 
   document.getElementById('userTableBody').innerHTML = renderTableRows(data);
 
@@ -50,58 +61,62 @@ const updateUserList = async (page = 1) => {
 };
 
 //검색 결과 렌더링
-const filterTableRows = (data) => {
-  const curPath = window.location.pathname;
-  console.log(data);
-  return `
-    <tr onclick="location.href='/admin/user/${data.userSn}'">
-      <td class="${style.td} ${style.name}">${data.name}</td>
-      <td class="${style.td} ${style.email}">${data.email}</td>
-      <td class="${style.td} ${style.phoneNumber}">${data.phoneNumber}</td>
-      <td class="${style.td} ${style.division}">${data.grade ? '관리자' : '임직원'}</td>
-   </tr>
-    `;
-};
-{
-  /* <td class="${style.td} checkbox"><input type="checkbox" onclick="event.stopPropagation()"></td> */
-}
+// const filterTableRows = (data) => {
+//   return `
+//     <tr onclick="location.href='/admin/user/${data.userSn}'">
+//       <td class="${style.td} ${style.name}">${data.name}</td>
+//       <td class="${style.td} ${style.email}">${data.email}</td>
+//       <td class="${style.td} ${style.phoneNumber}">${data.phoneNumber}</td>
+//       <td class="${style.td} ${style.division}">${data.grade ? '관리자' : '임직원'}</td>
+//    </tr>
+//     `;
+// };
+// {
+//   /* <td class="${style.td} checkbox"><input type="checkbox" onclick="event.stopPropagation()"></td> */
+// }
 
-const filterRender = async (searchTerm) => {
-  const data = await fetchUsers();
-  const userData = data.data;
-  const filteredUsers = userData.filter(
-    (user) => user.name.includes(searchTerm) || user.email.includes(searchTerm)
-  );
-  const tableRowsHTML = filteredUsers.map(filterTableRows).join('');
-  document.getElementById('userTableBody').innerHTML = tableRowsHTML;
+// const filterRender = async (searchTerm) => {
+//   let page = 1;
+//   const data = await fetchUsers(page, searchTerm);
+//   console.log(data)
+//   const userData = data.data;
+//   const filteredUsers = userData.filter(
+//     (user) => user.name.includes(searchTerm) || user.email.includes(searchTerm)
+//   );
+//   const tableRowsHTML = filteredUsers.map(filterTableRows).join('');
+//   document.getElementById('userTableBody').innerHTML = tableRowsHTML;
 
-  document.getElementById('userCount').textContent =
-    `총 ${filteredUsers.length}명의 임직원`;
+//   document.getElementById('userCount').textContent =
+//     `총 ${filteredUsers.length}명의 임직원`;
 
-  setupPagination(1, filteredUsers.length);
-};
+//   setupPagination((Math.ceil(filteredUsers.length / 5)), page);
+// };
 
-let currentSearchTerm = '';
+let currentSearchTerm = ''; //전역 변수
+
 const userListFunc = async () => {
   const { totalPage } = await fetchUsers();
   const paginationButtons = document.getElementById('paginationButtons');
   const searchInput = document.getElementById('searchInput');
   //첫 번째 페이지로 초기화
   setupPagination(totalPage, 1);
-  const searchUsers = async () => {
-    currentSearchTerm = searchInput.value.toLowerCase(); // 전역 변수에 검색어 저장
 
-    filterRender(currentSearchTerm);
-  };
   // 페이지네이션 버튼 이벤트 리스너 추가
   paginationButtons.addEventListener('click', (event) => {
     handlePagination(event, totalPage);
   });
+
+  const searchUsers = async () => {
+    currentSearchTerm = searchInput.value.toLowerCase(); // 전역 변수에 검색어 저장
+
+   await updateUserList();
+  };
   // 검색 이벤트 리스너
   searchInput.addEventListener('keydown', (e) => {
     if (e.key === 'Enter') {
       searchUsers();
     }
+
   });
 };
 

--- a/src/pages/admin/userList/userListFunc.js
+++ b/src/pages/admin/userList/userListFunc.js
@@ -1,10 +1,17 @@
 import { pagination } from './userListRender';
 import { renderTableRows } from './userListRender';
-// import style from './userList.module.css';
+
+const DEFAULT_PAGE = 1; //기본 페이지
+const PAGE_SIZE = 5; //출력 데이터 수
+
+const state = {
+  currentSearchTerm: '', //검색어
+  currentPage: DEFAULT_PAGE //현재 페이지
+};
 
 // 임직원 리스트 API 호출 함수
 export const fetchUsers = async (page = 1, searchTerm = '') => {
-  const url = `/api/admin/userList?page=${page}&search=${searchTerm}`;
+  const url = `/api/admin/userList?page=${page}&search=${encodeURIComponent(searchTerm)}`;
   try {
     const response = await fetch(url);
     if (!response.ok) throw new Error('Failed to fetch items');
@@ -13,19 +20,24 @@ export const fetchUsers = async (page = 1, searchTerm = '') => {
     console.error('Error fetching items:', error);
   }
 };
+
 //검색어 포함 api 호출 함수
-export const getUsers = async (page = 1) => {
-  if (currentSearchTerm) {
-    return await fetchUsers(page, currentSearchTerm);
-  }else{
-    return await fetchUsers(page);
-  };
+export const getUsers = async (page = DEFAULT_PAGE) => {
+  if (state.currentSearchTerm) {
+    return await fetchUsers(page, state.currentSearchTerm);
+  } else if(!state.currentSearchTerm){
+    return await fetchUsers(page)
+  }
 }
+
 // 페이지네이션 버튼 핸들러
 const handlePagination = async (event, totalPage) => {
   const target = event.target;
-  let currentPage = parseInt(document.querySelector('.pageBtn').innerText);
+  if(target.tagName !== 'BUTTON') return;
+
+  const currentPage = state.currentPage;
   let newPage = currentPage;
+
   if (target.classList.contains('prev') && currentPage > 1) {
     newPage = currentPage - 1;
   } else if (target.classList.contains('next') && currentPage < totalPage) {
@@ -33,91 +45,59 @@ const handlePagination = async (event, totalPage) => {
   } else {
     newPage = parseInt(target.innerText, 10);
   }
+
   if (newPage !== currentPage) {
-    currentPage = newPage;
+    state.currentPage = newPage;
     await updateUserList(newPage);
   }
 };
 
 //페이지네이션
-const setupPagination = (totalPage, currentPage = 1) => {
+const setupPagination = (totalPage) => {
   if(totalPage > 0){
     const paginationButtons = document.getElementById('paginationButtons');
-    paginationButtons.innerHTML = pagination(currentPage, totalPage);
+    paginationButtons.innerHTML = pagination(state.currentPage, totalPage);
   }
 };
 
 // 임직원 리스트 업데이트 함수
-const updateUserList = async (page = 1) => {
+const updateUserList = async (page = DEFAULT_PAGE) => {
   const { data, totalCount, totalPage } = await getUsers(page);
-  console.log(totalCount)
-
   document.getElementById('userTableBody').innerHTML = renderTableRows(data);
 
   document.getElementById('userCount').textContent =
     `총 ${totalCount}명의 임직원`;
 
-  setupPagination(totalPage, page);
+  setupPagination(totalPage);
 };
 
-//검색 결과 렌더링
-// const filterTableRows = (data) => {
-//   return `
-//     <tr onclick="location.href='/admin/user/${data.userSn}'">
-//       <td class="${style.td} ${style.name}">${data.name}</td>
-//       <td class="${style.td} ${style.email}">${data.email}</td>
-//       <td class="${style.td} ${style.phoneNumber}">${data.phoneNumber}</td>
-//       <td class="${style.td} ${style.division}">${data.grade ? '관리자' : '임직원'}</td>
-//    </tr>
-//     `;
-// };
-// {
-//   /* <td class="${style.td} checkbox"><input type="checkbox" onclick="event.stopPropagation()"></td> */
-// }
+//검색어 처리 함수
+const searchUsers = async () =>{
+  state.currentSearchTerm = document.getElementById('searchInput').value.toLowerCase(); // 전역 변수에 검색어 저장
+  state.currentPage = DEFAULT_PAGE
+  await updateUserList();
+}
 
-// const filterRender = async (searchTerm) => {
-//   let page = 1;
-//   const data = await fetchUsers(page, searchTerm);
-//   console.log(data)
-//   const userData = data.data;
-//   const filteredUsers = userData.filter(
-//     (user) => user.name.includes(searchTerm) || user.email.includes(searchTerm)
-//   );
-//   const tableRowsHTML = filteredUsers.map(filterTableRows).join('');
-//   document.getElementById('userTableBody').innerHTML = tableRowsHTML;
+//이벤트 초기화 함수
+const initEventLister = (totalPage) => {
+  //페이지네이션 이벤트리스너 추가
+  document.getElementById('paginationButtons').addEventListener('click', (event) =>{
+    handlePagination(event, totalPage)
+  })
 
-//   document.getElementById('userCount').textContent =
-//     `총 ${filteredUsers.length}명의 임직원`;
-
-//   setupPagination((Math.ceil(filteredUsers.length / 5)), page);
-// };
-
-let currentSearchTerm = ''; //전역 변수
-
-const userListFunc = async () => {
-  const { totalPage } = await fetchUsers();
-  const paginationButtons = document.getElementById('paginationButtons');
-  const searchInput = document.getElementById('searchInput');
-  //첫 번째 페이지로 초기화
-  setupPagination(totalPage, 1);
-
-  // 페이지네이션 버튼 이벤트 리스너 추가
-  paginationButtons.addEventListener('click', (event) => {
-    handlePagination(event, totalPage);
-  });
-
-  const searchUsers = async () => {
-    currentSearchTerm = searchInput.value.toLowerCase(); // 전역 변수에 검색어 저장
-
-   await updateUserList();
-  };
-  // 검색 이벤트 리스너
-  searchInput.addEventListener('keydown', (e) => {
-    if (e.key === 'Enter') {
-      searchUsers();
+  //검색 이벤트 리스너 추가
+  document.getElementById('searchInput').addEventListener('keydown', (event) => {
+    if(event.key === 'Enter'){
+      searchUsers()
     }
+  })
+}
 
-  });
+//최초 초기화 함수
+const userListFunc = async () => {
+  const { totalPage } = await fetchUsers();  
+  setupPagination(totalPage);
+  initEventLister(totalPage);
 };
 
 export default userListFunc;

--- a/src/pages/admin/userList/userListRender.js
+++ b/src/pages/admin/userList/userListRender.js
@@ -75,7 +75,6 @@ const userListRender = async () => {
         <table class="${style.table}">
           <thead>
             <tr>
-              <th class="${style.th} checkbox"></th>
               <th class="${style.th} name">이름</th>
               <th class="${style.th} ${style.email}">이메일</th>
               <th class="${style.th} ${style.phoneNumber}">휴대폰번호</th>

--- a/src/pages/admin/userList/userListRender.js
+++ b/src/pages/admin/userList/userListRender.js
@@ -16,15 +16,13 @@ export const renderTableRows = (data) => {
     )
     .join('');
 };
-{
-  /* <td class="${style.td} checkbox"><input type="checkbox" onclick="event.stopPropagation()"></td> */
-}
+
 
 // 페이지네이션 버튼을 렌더링하는 함수
 export const pagination = (currentPage, totalPage) => {
   const pageButton = [];
-  const startPage = Math.max(currentPage - 5, 1);
 
+  const startPage = Math.max(currentPage - 5, 1);
   const endPage = Math.min(startPage + 9, totalPage);
 
   for (let i = startPage; i <= endPage; i++) {

--- a/src/pages/admin/userList/userListRender.js
+++ b/src/pages/admin/userList/userListRender.js
@@ -3,7 +3,6 @@ import { fetchUsers } from './userListFunc';
 
 // 테이블의 행을 렌더링하는 함수
 export const renderTableRows = (data) => {
-  console.log(data);
   return data
     .map(
       (item) => `
@@ -55,7 +54,6 @@ const userListRender = async () => {
   const userData = await fetchUsers(); // 패치함수 실행
   const totalCount = userData.totalCount; // 총 임직원
   const data = userData.data; // 임직원 데이터
-  console.log(userData);
 
   return `
     <div class="${style.userListWrapper}">


### PR DESCRIPTION
### 📝 Description

임직원 관리 페이지 검색 기능 출력된 페이지 단순 필터링에서 검색된 인물 모두 출력되도록 수정
추가) 리팩토링 진행

### 💻 How To Test

npm run server npm run dev
- 관리자 로그인 후 http://localhost:5173/admin/userList 접근
- 검색 가능한 데이터 필요

### 💽 Commits

1. 이름 또는 이메일 검색 시 검색 내용 포함된 결과 5개까지 출력되도록 변경
2. 검색 결과 5개 초과시 2페이지 생성(수정 전 작동X)
3. 검색 입력값 없을 경우, 전체 데이터 출력
추가) 임직원관리리스트 리팩토링
상수화 및 함수 추출, 역할분리


### 🖼 결과

![image](https://github.com/user-attachments/assets/b9cf3f65-c7db-4e07-a349-39ef5cf5d881)
