### PR TITLE
refact : 관리자 부재관리 페이지 table css 적용

### DIFF
--- a/src/pages/admin/absence/absenceRender.js
+++ b/src/pages/admin/absence/absenceRender.js
@@ -1,4 +1,5 @@
 import '../../../assets/css/buttons.css'
+import '../../../assets/css/table.css';
 import styles from './adminAbsence.module.css';
 import { fetchAdminAbsence } from './absenceFunc';
 
@@ -7,8 +8,6 @@ const absenceRender = async () => {
   const { data } = await fetchAdminAbsence();
 
   return `
-    <h1 class="${styles.title}">부재 관리</h1>
-
     <div class="${styles.content}">
 
       <section class="${styles.searchWrap}">

--- a/src/pages/admin/absence/adminAbsence.module.css
+++ b/src/pages/admin/absence/adminAbsence.module.css
@@ -1,13 +1,3 @@
-.title {
-  font-size: 30px;
-  font-weight: bold;
-  margin-top: 20px;
-}
-
-.content {
-  margin: 20px auto 0;
-}
-
 .searchWrap {
   display: flex;
   justify-content: flex-end;
@@ -42,23 +32,6 @@
   height: 18px;
 }
 
-.absenceList {
-  width: 100%;
-  line-height: 39px;
-  margin: 20px auto 0;
-  text-align: left;
-  border-collapse: collapse;
-  border-spacing: 0;
-}
-.absenceList th {
-  background-color: #f2f2f2;
-  border: none;
-}
-.absenceList th:first-child,
-.absenceList td:first-child {
-  padding-left: 10px;
-}
-
 .pagination {
   display: flex;
   align-items: center;
@@ -88,8 +61,4 @@
     display: none;
   }
 
-  .absenceList th:nth-child(2),
-  .absenceList td:nth-child(2) {
-    padding-left: 10px;
-  }
 }


### PR DESCRIPTION
### 📝 Description

refact : 관리자 부재관리 페이지 table css 적용

### 💻 How To Test
```
npm run server
npm run dev
```
관리자 로그인 후 /admin/absence 화면 진입

### 💽 Commits

refact : 관리자 부재관리 페이지 table css 적용

### 🖼 결과

![image](https://github.com/user-attachments/assets/4b1edc91-f2c6-4aea-bbd5-69d4ba512208)
