### PR TITLE
fix : 레이아웃의 네비게이트가 존재할 때만 이벤트 리스너 적용하도록 수정

### DIFF
--- a/src/components/layout/layoutInit.js
+++ b/src/components/layout/layoutInit.js
@@ -58,11 +58,13 @@ const layoutInit = () => {
     return null;
   };
 
-  menu.addEventListener('click', openModal);
-  navigate.addEventListener('click', closeModal);
-  navSignOutBtn.addEventListener('click', signOut);
-  headSignOutBtn.addEventListener('click', signOut);
-  intranetTitle.textContent = matchRoute(path, routes);
+  if (navigate) {
+    menu.addEventListener('click', openModal);
+    navigate.addEventListener('click', closeModal);
+    navSignOutBtn.addEventListener('click', signOut);
+    headSignOutBtn.addEventListener('click', signOut);
+    intranetTitle.textContent = matchRoute(path, routes);
+  }
 };
 
 export default layoutInit;


### PR DESCRIPTION
### 📝 Description

레이아웃의 네비게이트가 존재할 때만 이벤트 리스너 적용하도록 수정

### 💻 How To Test


### 💽 Commits

구현 사항 요약
1. 레이아웃의 네비게이트가 존재할 때만 이벤트 리스너 적용하도록 수정


### 🖼 결과

ex) 실행, 테스트 결과 또는 사진 첨부
